### PR TITLE
feat: Make final SFTP failure a critical error

### DIFF
--- a/oclc-sync.ps1
+++ b/oclc-sync.ps1
@@ -312,10 +312,9 @@ Function Process-OclcOperation {
                 if ($sftpSuccess) {
                     Write-Log -Level INFO -Message "      SUCCESS: SFTP upload for '$csvFileName' completed successfully."
                 } else {
-                    # --- MODIFIED BEHAVIOR ---
-                    # The final failure after all retries is now logged as a WARNING.
-                    # This ensures the script continues without flagging a critical error.
-                    Write-Log -Level WARN -Message "      SFTP FAILURE: Upload for '$csvFileName' did not succeed after all $maxRetries attempts."
+                    # The final failure after all retries is logged as a critical ERROR.
+                    # This ensures the script stops and flags a critical error.
+                    Write-Log -Level ERROR -Message "      SFTP CRITICAL FAILURE: Upload for '$csvFileName' did not succeed after all $maxRetries attempts."
                 }
             } else {
                 Write-Log -Level INFO -Message "      SFTP: Skipping upload for Org: $orgName as no records were exported."


### PR DESCRIPTION
Changed the log level for WinSCP SFTP failures after all retries have been exhausted from WARN to ERROR. This ensures that a persistent SFTP failure is treated as a critical error by the script's error handling logic.

Individual SFTP attempts that fail but are retried will continue to be logged as WARN, as this does not represent a fatal error for the process. This corrects a previous implementation where all SFTP failures were incorrectly logged as errors.